### PR TITLE
Publier au merge sur la branche master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
   - 10
 branches:
   only:
-    - published
+    - master
 
 cache:
   directories:
@@ -25,4 +25,4 @@ deploy:
   github-token: $GITHUB_TOKEN # Set in the settings page of your repository, as a secure variable
   keep-history: true
   on:
-    branch: published
+    branch: master

--- a/README.md
+++ b/README.md
@@ -59,7 +59,4 @@ npm run generate
 
 ### Déployer
 
-1. merger la branche `master` dans la branche `published`
-2. `git push`
-
-Le déploiement du site est déclenché automatiquement par _Travis_ lors d'un _push_ sur la branche `published`. Il peut prendre quelques minutes avant d'être visible en production.
+Le déploiement du site est déclenché automatiquement par _Travis_ lors d'un merge sur la branche `master`. Il peut prendre quelques minutes (environ 3 minutes habituellement) avant d'être visible en production.


### PR DESCRIPTION
Maintenant que la `popcorn-machine` est séparée des contenus, on peut simplement lancer la publication dès qu'une pull request est acceptée sur le master, et la branche "published" et "dev" peuvent disparaitre. (ce qui sera fait une fois cette PR approuvée)