### PR TITLE
#148 Update DOM for search results

### DIFF
--- a/static/search.js
+++ b/static/search.js
@@ -12,16 +12,18 @@ fetch("/api/search-index.json")
 search.addEventListener("input", (event) => {
   if (searchIndex) {
     let value = event.target.value;
-    let results = searchPersons(searchIndex, value);
-    const resultsIds = results.map((person) => person.id);
-    const matches = document.querySelectorAll('[data-type="person"]');
-    matches.forEach((match) => {
-      if (!resultsIds.includes(match.id)) {
-        match.style.display = "none";
-      } else {
-        match.style.display = "block";
-      }
-    });
+    if (value.length > 0) {
+      let results = searchPersons(searchIndex, value);
+      const searchResults = document.getElementById("search-results");
+      document.getElementById("persons").style.display = "none";
+      searchResults.style.display = "flex";
+      searchResults.innerHTML = results
+        .map((person) => document.getElementById(person.id).outerHTML)
+        .join("");
+    } else {
+      document.getElementById("persons").style.display = "flex";
+      document.getElementById("search-results").style.display = "none";
+    }
   }
 });
 

--- a/views/index.njk
+++ b/views/index.njk
@@ -21,7 +21,9 @@
     {% include "searchBar.njk" %}
   </div>
 
-  <div class="container mx-auto flex flex-wrap mb-6">
+  <div id="search-results" class="container mx-auto flex flex-wrap mb-6">
+  </div>
+  <div id="persons" class="container mx-auto flex flex-wrap mb-6">
     {% for person in persons %}
       <div data-type="person" class="w-full sm:w-1/2 md:w-1/2 lg:w-1/3 xl:w-1/4 p-2" id="{{person.$slug}}" >
         <div class="bg-white shadow rounded">


### PR DESCRIPTION
Fix #148 : Lors de la recherche de "Java" on devrait faire ressortir les profils "Java" avant les profils "JavaScript".

Pour cela il est nécessaire de réécrire le DOM avec les résultats triés