### PR TITLE
proposition d'ajout des statistiques avec matomo

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,2 +1,3 @@
 SITE_BASE_URL = https://popcorn-nantes.github.io
 CONTACT_ALL_FREELANCES_FORM_LINK = https://form.jotform.com/abc
+ENABLE_ANALYTICS = 0

--- a/build.js
+++ b/build.js
@@ -28,6 +28,7 @@ const views = new nunjucks.Environment(loader, {
 
 views.addGlobal("SITE_NAME", config.SITE_NAME);
 views.addGlobal("SITE_BASE_URL", process.env.SITE_BASE_URL);
+views.addGlobal("ENABLE_ANALYTICS", process.env.ENABLE_ANALYTICS);
 views.addGlobal(
   "CONTACT_ALL_FREELANCES_FORM_LINK",
   process.env.CONTACT_ALL_FREELANCES_FORM_LINK

--- a/views/layout.njk
+++ b/views/layout.njk
@@ -4,6 +4,26 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <link rel="stylesheet" type="text/css" href="/app.css">
+
+    {% if process.env.ENABLE_ANALYTICS  %}
+    <!-- Matomo -->
+    <script type="text/javascript">
+      var _paq = window._paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="https://fireblogcms.matomo.cloud/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '5']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/fireblogcms.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    
+    <!-- End Matomo Code -->
+    {% endif %}
+
     {% block head %} {% endblock %}
   </head>
   <body>

--- a/views/layout.njk
+++ b/views/layout.njk
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <link rel="stylesheet" type="text/css" href="/app.css">
 
-    {% if process.env.ENABLE_ANALYTICS  %}
+    {% if process.env.ENABLE_ANALYTICS == 1  %}
     <!-- Matomo -->
     <script type="text/javascript">
       var _paq = window._paq = window._paq || [];
@@ -20,7 +20,7 @@
         g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/fireblogcms.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
       })();
     </script>
-    
+
     <!-- End Matomo Code -->
     {% endif %}
 

--- a/views/layout.njk
+++ b/views/layout.njk
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <link rel="stylesheet" type="text/css" href="/app.css">
 
-    {% if process.env.ENABLE_ANALYTICS == 1  %}
     <!-- Matomo -->
+    {% if ENABLE_ANALYTICS == 1  %}
     <script type="text/javascript">
       var _paq = window._paq = window._paq || [];
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -20,9 +20,8 @@
         g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/fireblogcms.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
       })();
     </script>
-
-    <!-- End Matomo Code -->
     {% endif %}
+    <!-- End Matomo Code -->
 
     {% block head %} {% endblock %}
   </head>


### PR DESCRIPTION
J'ai un matomo en cloud pour un autre projet. Je peux y ajouter un suivi pour Popcorn Nantes dessus si on merge cette PR, pour qu'on ait une idée des visites et potentiellement des recherches ( mais pas sûr qu'on puisse savoir pour les recherches sans implémenter un bouton "submit" pour déclencher une recherche)

Pour que ça marche, ajouter:

**ENABLE_ANALYTICS = 1** 

dans le script de build de github actions !